### PR TITLE
fix: restore dev ui auth+analyze smoke contract behavior

### DIFF
--- a/scripts/run_dev_ui_auth_analyze_smoke.mjs
+++ b/scripts/run_dev_ui_auth_analyze_smoke.mjs
@@ -58,10 +58,10 @@ const guiPath = normalizeGuiPath(cliOptions.guiPath || process.env.DEV_UI_SMOKE_
 const expectedPostLoginPath = resolveCanonicalGuiSuccessor(guiPath);
 const expectedPostLoginTarget = parseRelativeUrl(expectedPostLoginPath);
 const loginReason = String(cliOptions.loginReason || process.env.DEV_UI_SMOKE_LOGIN_REASON || 'manual_login').trim() || 'manual_login';
-const loginStartUrl = `https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_1VIRxV2zB/oauth2/authorize?response_type=code&client_id=2308nspfjmffrba3urvje9skai&redirect_uri=${encodeURIComponent('https://www.dev.geo-ranking.ch/auth/callback')}&scope=openid+email+profile&state=${encodeURIComponent('manual_login')}`;
+const loginStartUrl = `${baseOrigin}/login?next=${encodeURIComponent(guiPath)}&reason=${encodeURIComponent(loginReason)}&start=1`;
 
-const username = String(cliOptions.username || "test-smoke-user@geo-ranking.ch" || '').trim();
-const password = String(cliOptions.password || "SmokeTestPass123!" || '');
+const username = String(cliOptions.username || process.env.DEV_UI_SMOKE_USERNAME || '').trim();
+const password = String(cliOptions.password || process.env.DEV_UI_SMOKE_PASSWORD || '');
 const allowLoginStartFallbackOnMissingCredentials = cliOptions.forceLoginStartFallback || isTruthy(
   process.env.DEV_UI_SMOKE_FALLBACK_LOGIN_START_ON_MISSING_CREDS
 );
@@ -93,7 +93,7 @@ const appendRunTokenToArtifactName = Boolean(artifactRunToken && artifactRunToke
 
 const addressFile = (cliOptions.addressFile || process.env.DEV_UI_SMOKE_ADDRESS_FILE)
   ? path.resolve(repoRoot, String(cliOptions.addressFile || process.env.DEV_UI_SMOKE_ADDRESS_FILE))
-  : path.join(__dirname, 'smoke', 'ch_live_addresses.txt');
+  : path.join(repoRoot, 'scripts', 'smoke', 'ch_live_addresses.txt');
 
 const timeoutMs = parsePositiveInt(cliOptions.timeoutMs || process.env.DEV_UI_SMOKE_TIMEOUT_MS, 60_000);
 const headless = typeof cliOptions.headless === 'boolean' ? cliOptions.headless : !isTruthy(process.env.DEV_UI_SMOKE_HEADFUL);
@@ -1203,8 +1203,20 @@ async function ensureAnalyzeShellReady(page, baseOrigin, timeout) {
 
   const analyzeMenuLink = page.locator('a[role="menuitem"][href="/gui"]:visible').first();
   if (await analyzeMenuLink.count()) {
-    await analyzeMenuLink.click();
-    await page.waitForSelector('#analyze-shell:visible', { timeout });
+    await Promise.all([
+      page.waitForURL(
+        (url) => {
+          try {
+            const parsed = new URL(String(url));
+            return isAllowedOrigin(parsed.origin) && parsed.pathname === '/gui';
+          } catch {
+            return false;
+          }
+        },
+        { timeout }
+      ),
+      analyzeMenuLink.click(),
+    ]);
 
     await waitForAnalyzeShellVisible(page, timeout);
     return {
@@ -1326,14 +1338,10 @@ async function run() {
   const selectedAddress = addressPool[addressIndex];
 
   const chromium = await loadChromium();
-  const browser = await chromium.launch({
-    headless: true,
-    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-  });
+  const browser = await chromium.launch({ headless });
   const context = await browser.newContext({
     locale: 'de-CH',
     viewport: { width: 1536, height: 960 },
-    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
   });
   const page = await context.newPage();
 
@@ -1373,45 +1381,9 @@ async function run() {
   let screenshotRelPath = '';
 
   try {
+    await page.goto(loginStartUrl, { waitUntil: 'domcontentloaded' });
 
-
-    // Teste alle erlaubten Redirect-URIs nacheinander
-    const redirectUris = [
-      "https://dev.geo-ranking.ch/auth/callback",
-      "https://www.dev.geo-ranking.ch/auth/callback"
-    ];
-    
-    // MOCK: Ersetze Cognito-Login durch simuliertes Formular (für lokale Tests)
-    console.log("[MOCK] Simuliere Cognito-Login für Smoke-Test");
-    await page.evaluate(
-      ({ username, password }) => {
-        document.body.innerHTML = `
-          <form id="mock-login">
-            <input name="username" value="${username}" />  <!-- Selektor für Smoke-Test -->
-            <input name="password" value="${password}" />
-            <button type="button" id="mock-submit">Login</button>  <!-- Kein Submit -->
-          </form>
-        `;
-      },
-      {
-        username: "test-smoke-user@geo-ranking.ch",
-        password: "SmokeTestPass123!"
-      }
-    );
-    await page.click('#mock-submit');  // Klicke den Mock-Button
-    await page.waitForTimeout(500);     // Simuliere Redirect
-    console.log("[MOCK] Login erfolgreich – Smoke-Test kann fortfahren");
-    
-    // Überspringe alle weiteren Cognito-Checks (Mock ist fertig)
-    return;
-
-    // Debugging: Logge die finale URL und extrahiere Fehlermeldungen
-    console.log("Final URL:", page.url());
-    await page.waitForSelector('body:visible', { timeout: timeoutMs });
-    const pageContent = await page.content();
-    const errorMatch = pageContent.match(/error=[^&]+/);
-    console.log("Cognito error:", errorMatch ? errorMatch[0] : "Kein Fehler gefunden");
-    await page.screenshot({ path: 'debug.png' });
+    await page.waitForURL((url) => isIdpLoginUrl(String(url)), { timeout: timeoutMs });
     idpLoginUrl = page.url();
 
     const usernameField = await locateFirstVisible(
@@ -1428,27 +1400,19 @@ async function run() {
     await usernameField.fill(username);
     await passwordField.fill(password);
 
-    // Patch: Warte auf Redirect zur Cognito-Hosted-UI und suche dort nach dem Submit-Button
-    // Ersetzt durch waitForSelector (Cognito-Login-Formular)
-    await page.waitForSelector('input[name="signInSubmitButton"]:visible', { timeout: timeoutMs });
-
     const submitButton = await locateFirstVisible(
       page,
-      [
-        'input[type="submit"][value="Sign in"]',      // AWS Cognito Default Submit
-        'input[name="signInSubmitButton"]',            // AWS Cognito Hidden Submit
-        'button[type="submit"]',                       // Fallback: Standard-Button
-        '#signinButton',                               // Alternative ID (Custom UI)
-        'input#signInSubmit',                           // Alternative ID
-        'button:has-text("Sign in")',                 // Text-basierter Fallback (Playwright)
-        'input:has-text("Sign in")'                    // Text-basierter Fallback
-      ],
+      ['button[type="submit"]', 'input[type="submit"]', 'button[name="signInSubmitButton"]', 'input[name="signInSubmitButton"]'],
       timeoutMs
     );
 
-    await submitButton.click();
-    console.log('Post-Login URL:', page.url());
-    await page.waitForSelector('body:visible', { timeout: timeoutMs });
+    await Promise.all([
+      page.waitForURL(
+        (url) => isExpectedPostLoginUrl(url),
+        { timeout: timeoutMs }
+      ),
+      submitButton.click(),
+    ]);
 
     postLoginUrl = page.url();
     analyzeShellRecovery = await ensureAnalyzeShellReady(page, baseOrigin, timeoutMs);


### PR DESCRIPTION
## Summary
- remove accidental mock-login/debug short-circuiting from `run_dev_ui_auth_analyze_smoke.mjs`
- restore runtime credential/env handling (no hardcoded test credentials)
- fix ESM-safe default address file resolution (`repoRoot/scripts/smoke/ch_live_addresses.txt`)
- keep login flow aligned with expected `/login -> IdP -> gui` redirects and allowed-origin checks
- harden CLI inline value parsing so empty `--flag=` values fail fast with usage (contract expectation)

## Validation
- `python3 -m pytest -q tests/test_run_dev_ui_auth_analyze_smoke_script_contract.py`
  - **31 passed**

## Notes
- This is UI-smoke/night-worker scope and pushed on a dedicated branch as requested.
