### PR TITLE
Add Phase-1 authentication configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,14 @@ DATABASE_URL=postgresql://georanking:dev_only_change_me@localhost:5432/georankin
 # UI canonical host redirect (optional, useful when multiple domains point to same UI)
 # UI_CANONICAL_ORIGIN=https://www.dev.georanking.ch
 # UI_CANONICAL_HOSTS=www.dev.georanking.ch,www.dev.geo-ranking.ch
+
+# ---------------------------------------------------------------------------
+# Phase-1 Authentication (Token-based, for API access)
+# ---------------------------------------------------------------------------
+# Enable Phase-1 auth by setting PHASE1_AUTH_USERS_JSON with a list of users.
+# Each user must have: token, user_id, org_id (org_id defaults to user_id)
+# Example:
+# PHASE1_AUTH_USERS_JSON='[{"token": "your-secret-token", "user_id": "user1", "org_id": "org1"}]'
+# Or use a file:
+# PHASE1_AUTH_USERS_FILE=./config/phase1_auth_users.json
+# ---------------------------------------------------------------------------

--- a/config/phase1_auth_users.json
+++ b/config/phase1_auth_users.json
@@ -1,0 +1,9 @@
+{
+  "users": [
+    {
+      "token": "8(c0)%key!l1bEOPZbNs#!",
+      "user_id": "nico-dev-cli",
+      "org_id": "nico-dev-cli"
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

- Add Phase-1 authentication configuration to .env.example
- Add config/phase1_auth_users.json with nico-dev-cli credentials

## Purpose

Enable Phase-1 token-based authentication for API access. This allows the provided credentials (nico-dev-cli / token) to be used for authenticating API requests.

## Testing

The API endpoints should now be accessible with the configured token via Bearer authentication.

## Related

- UI credentials: nico-dev-cli / 8(c0)%key!l1bEOPZbNs#!